### PR TITLE
Adiciona link para o Waffle no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 O coletivo nacional de Juventude Enegrecer é uma expressão do movimento social negro que luta contra as opressões da sociedade em favor da juventude negra. O projeto se propõe como uma plataforma para registrar denúncias de crimes raciais, a fim de se coletar dados para embasar e guiar ações e políticas antirracismo.
 
-O Web App implementado neste respositório é uma das interfaces para essa plataforma, onde o usuário pode se informar mais a respeito e relatar um crime. As denúncias, ou relatos podem ser anônimos, mas é oferecido ao usuário a possibilidade de se identificar, podendo este se cadastrar como usuário da plataforma.
+O Web App implementado neste respositório é uma das interfaces para essa plataforma, onde o usuário pode se informar mais a respeito e relatar um crime.
 
 
 ## Configurações

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Na nossa stack temos:
 
 ## Mais Informações
 
-[Para mais informações, acesse a nossa wiki :)](https://github.com/Enegrecer/enegrecer-web/wiki)
+[Para mais informações, acesse a nossa wiki :)](https://github.com/Enegrecer/enegrecer-web/wiki).
 
-Ou junte-se ao nosso espaço no [Gitter](https://gitter.im/Coletivo-Enegrecer/Enegrecer)
+Ou junte-se ao nosso espaço no [Gitter](https://gitter.im/Coletivo-Enegrecer/Enegrecer).
+
+Nós usamos o [waffle](https://waffle.io/Enegrecer/enegrecer-web) para visualizar e organizar nossas issues.


### PR DESCRIPTION
Olá, adicionei um link para o nosso board do waffle no final do nosso README principal.

Por ser uma modificação simples não achei necessário abrir uma issue para tal. Se precisar me avisem que eu crio :)