### PR TITLE
Adicionando "Test Reporter ID" do Code Climate na configuração do Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=cf96d355f42b24786c56534ca0ad370145c669bda3f7789a85e9fed326cd945c
 language: node_js
 cache:
   yarn: true


### PR DESCRIPTION
Esse pull request visa corrigir o problema no Travis quando os testes unitários são rodados a partir de um pull request de um `fork` do projeto. O problema existe pois na configuração do Travis não existe o token `Test Reporter ID` do Code Climate, necessário para enviar o relatório de `coverage` dos testes.