### PR TITLE
Adicionando Code Climate Reporter Token no arquivo .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=cf96d355f42b24786c56534ca0ad370145c669bda3f7789a85e9fed326cd945c
 language: node_js
 cache:
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
   global:
-    - CC_TEST_REPORTER_ID=cf96d355f42b24786c56534ca0ad370145c669bda3f7789a85e9fed326cd945c
+    - CODECLIMATE_REPO_TOKEN=cf96d355f42b24786c56534ca0ad370145c669bda3f7789a85e9fed326cd945c
 language: node_js
 cache:
   yarn: true


### PR DESCRIPTION
Esse pull request visa corrigir o problema no Travis quando os testes unitários são rodados a partir de um pull request de um fork do projeto. O problema existe pois o Travis não aplica as variáveis de ambiente definidas nas configurações do projeto em [forks](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings).

Com isso, é preciso adicionar essa variável no arquivo `.travis.yml`. Como não é um token sensível, já que ele apenas da permissão para enviar um report, [não há problema em adicioná-lo no arquivo, além de ser recomendado pelo Code Climate](https://docs.codeclimate.com/docs/test-coverage-troubleshooting-tips#section--should-i-keep-my-test-coverage-token-secret-).