### PR TITLE
:green_heart a validação do eslint já está no travis, não sendo neces…

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,11 +1,7 @@
 engines:
   eslint:
-    enabled: true
-    channel: "stable"
-    checks:
-      import/extensions:
-        enabled: false
-
+    enabled: false
+    
   csslint:
     enabled: true
   duplication:


### PR DESCRIPTION

### Requisitos

Remover a validação do eslint doi codeclimate porque esta já realizada no travis

### Descrição da Mudança

Remover a validação do eslint doi codeclimate porque esta já realizada no travis


### Benefícios

- Build mais rápido e evitar duplicão de validação.

### Possíveis Desvantagens

- N/a

### Issues relacionados

-n/A

### Abordagens Alternativas

- N/A
