### PR TITLE
[Fix-private-routes] Coloca as rotas de visulizar denuncia visiveis somente ao moderador

### DIFF
--- a/src/components/moderador/DenunciaRow.js
+++ b/src/components/moderador/DenunciaRow.js
@@ -37,7 +37,7 @@ class DenunciaRow extends Component {
           <td>{agressao.cidade}</td>
           <td>{agressao.bairro}</td>
           <td>
-            <Link to={`/visualizar-denuncia/${denuncia.id}`} className="mais-detalhes" onClick={cliqueDetalhesDenuncia(this)}> mais detalhes </Link>
+            <Link to={`/moderador/visualizar-denuncia/${denuncia.id}`} className="mais-detalhes" onClick={cliqueDetalhesDenuncia(this)}> mais detalhes </Link>
           </td>
           <td width="50px">
             <input

--- a/src/routes/Routes.js
+++ b/src/routes/Routes.js
@@ -26,7 +26,7 @@ const Routes = () => (
         <Route exact path="/denunciar" component={NovaDenunciaContainer} />
         <Route exact path="/depois-denuncia" component={DepoisDaDenuncia} />
         <Route exact path="/login" component={ModeradorLogin} />
-        <Route exact path="/visualizar-denuncia/:denunciaId" component={VisualizarDenunciaContainer} />
+        <Route exact path="/moderador/visualizar-denuncia/:denunciaId" component={VisualizarDenunciaContainer} />
         <PrivateRoute path="/moderador" component={PainelModerador} />
 
         <Route component={PaginaNaoEncontrada} />

--- a/src/routes/__snapshots__/Routes.test.js.snap
+++ b/src/routes/__snapshots__/Routes.test.js.snap
@@ -38,7 +38,7 @@ exports[`Routes com moderador logado deve construir a pagina com menu para moder
       <Route
         component={[Function]}
         exact={true}
-        path="/visualizar-denuncia/:denunciaId"
+        path="/moderador/visualizar-denuncia/:denunciaId"
       />
       <PrivateRoute
         component={[Function]}
@@ -91,7 +91,7 @@ exports[`Routes sem moderador logado deve construir a pagina com menu da página
       <Route
         component={[Function]}
         exact={true}
-        path="/visualizar-denuncia/:denunciaId"
+        path="/moderador/visualizar-denuncia/:denunciaId"
       />
       <PrivateRoute
         component={[Function]}


### PR DESCRIPTION

<!--

* Este é um modelo de Pull Request(PR) e serve para guiar a pessoa colaboradora que deseja submeter mudanças no projeto ***Verdade Seja Dita***.
* Caso você não veja necessidade ou sentido em descrever algum tópico, coloque algo como: "Não aplicável".
* Ao abrir uma Issue, é esperado que você tenha concordado com os termos descritos no nosso [código de conduta](CODE_OF_CONDUCT.md).

 -->

### Requisitos
N/A
<!--

* Um Pull Request(PR) que não inclua informações suficientes para ser revisado em tempo hábil(cerca 24h), pode dificultar o andamento das pessoas que mantém ou colaboram no projeto.
* Todo o código novo requer testes para evitar regressões: executando `yarn test-coverage` para ver a cobertura de testes do seu código
* Todos os testes unitários devem estar funcionando: rode `yarn test` para executar os testes unitários
* Passar todas as regras de linter/eslint: rode `yarn lint` para executar a análise de código
* Seguir as boas práticas de desenvolvimento de código

-->

### Descrição da Mudança
Coloca a página de `visualizar denuncia` sob a rota `/moderador` para que fique visível somente ao moderador.
<!--

* Devemos ser capazes de entender a abordagem da sua mudança a partir desta descrição. Se não tivermos uma boa idéia do que o código fará a partir da descrição aqui, o Pull Request(PR) pode ser revisado com dificuldade. 
* Tenha em mente que a pessoa mantenedora/colaboradora a cargo de revisar este PR pode não estar familiarizado(a) ou não ter trabalhado com o código recentemente, então, seja claro(a).

-->

### Benefícios
N/A
<!-- Quais benefícios serão realizados pela mudança de código? -->

### Possíveis Desvantagens

<!-- Quais são os possíveis efeitos colaterais ou impactos negativos da mudança de código? -->

### Issues relacionados
N/A
<!-- Informe quaisquer Issues relacionados aqui -->

### Abordagens Alternativas
N/A
<!-- Explique quais outras alternativas foram considerados e por que a versão proposta foi selecionada -->
