### PR TITLE
Altera campo gênero para texto livre.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ enegrecer-web.iml
 package-lock.json
 
 .idea/
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
     - stage: lint + test + security-tests
       script: yarn lint
     - script: yarn test
-    - 
+    -
       install: skip
       before_script: skip
       services:

--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
     "redux-saga": "^0.15.6"
   },
   "scripts": {
-    "start": "yarn build-css-local && ./node_modules/.bin/react-scripts start",
+    "start": "yarn build-css-local && npx react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "test-local": "../node_modules/.bin/react-scripts test --env=jsdom",
+    "test-local": "npx react-scripts test --env=jsdom",
     "test-coverage": "react-scripts test --env=jsdom --coverage && ./node_modules/codeclimate-test-reporter/bin/codeclimate.js < ./coverage/lcov.info",
     "eject": "react-scripts eject",
-    "lint": "./node_modules/.bin/eslint src --fix",
-    "all-tests-local": "yarn test-local --coverage && ../node_modules/.bin/eslint src --fix",
+    "lint": "npx eslint src --fix",
+    "all-tests-local": "yarn test-local --coverage && npx eslint src --fix",
     "watch-lint": "esw -w src",
-    "build-css-local": "./node_modules/.bin/node-sass-chokidar src/ -o src/",
+    "build-css-local": "npx node-sass-chokidar src/ -o src/",
     "build-css": "node-sass-chokidar src/ -o src/",
     "watch-css": "npm run build-css && node-sass-chokidar src/ -o src/ --watch --recursive"
   },

--- a/src/components/comum/campoTexto/__snapshots__/CampoTexto.test.js.snap
+++ b/src/components/comum/campoTexto/__snapshots__/CampoTexto.test.js.snap
@@ -6,12 +6,12 @@ exports[`CampoTexto não deve possuir estrutura definida  1`] = `
   onChange={[Function]}
 >
   <div>
-    <input
-      maxLength={3}
-    />
     <label
       className="active"
       data-success="right"
+    />
+    <input
+      maxLength={3}
     />
   </div>
 </campoTexto>

--- a/src/components/comum/campoTexto/index.js
+++ b/src/components/comum/campoTexto/index.js
@@ -12,6 +12,7 @@ const renderCampoTexto = ({
   const existeErroDeValidacao = touched && error;
   return (
     <div className={divClasse}>
+      <label className="active" data-error={error} data-success="right" htmlFor={id}>{label}</label>
       <input
         id={id}
         {...input}
@@ -20,7 +21,6 @@ const renderCampoTexto = ({
         maxLength={maxLen}
         placeholder={placeholder || undefined}
       />
-      <label className="active" data-error={error} data-success="right" htmlFor={id}>{label}</label>
     </div>
   );
 };

--- a/src/components/comum/data/__snapshots__/Data.test.js.snap
+++ b/src/components/comum/data/__snapshots__/Data.test.js.snap
@@ -22,13 +22,6 @@ exports[`Data deve possuir estrutura definida  1`] = `
     <div
       className=""
     >
-      <input
-        className="datepicker"
-        id="13"
-        maxLength={0}
-        placeholder="Data"
-        type="date"
-      />
       <label
         className="active"
         data-success="right"
@@ -36,6 +29,13 @@ exports[`Data deve possuir estrutura definida  1`] = `
       >
         Data
       </label>
+      <input
+        className="datepicker"
+        id="13"
+        maxLength={0}
+        placeholder="Data"
+        type="date"
+      />
     </div>
   </campoTexto>
 </Data>

--- a/src/components/comum/genero/__snapshots__/Genero.test.js.snap
+++ b/src/components/comum/genero/__snapshots__/Genero.test.js.snap
@@ -1,18 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Genero deve possuir estrutura definida  1`] = `
-<combobox
+<campoTexto
   divClasse=""
   id="13"
-  itens={
-    Array [
-      "Feminino",
-      "Masculino",
-    ]
-  }
   label="Gênero"
-  onChange={[Function]}
+  maxLen={40}
+  placeholder="Insira seu gênero ou deixe em branco caso prefira não exibi-lo"
   state="genero"
-  valorPadrao="Selecione seu gênero"
+  type="text"
 />
 `;

--- a/src/components/comum/genero/index.js
+++ b/src/components/comum/genero/index.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Combobox from '../combobox';
+import CampoTexto from '../campoTexto';
 
 const genero = ({ id, divClasse, state }) => (
-  <Combobox
+  <CampoTexto
     state={state}
     id={id}
     label="Gênero"
     divClasse={divClasse}
-    itens={['Feminino', 'Masculino']}
-    valorPadrao="Selecione seu gênero"
+    maxLen={40}
+    placeholder="Insira seu gênero ou deixe em branco caso prefira não exibi-lo"
+    type="text"
   />
 );
 

--- a/src/components/comum/genero/index.js
+++ b/src/components/comum/genero/index.js
@@ -4,9 +4,9 @@ import CampoTexto from '../campoTexto';
 
 const genero = ({ id, divClasse, state }) => (
   <CampoTexto
-    state={state}
     id={id}
     label="Gênero"
+    state={state}
     divClasse={divClasse}
     maxLen={40}
     placeholder="Insira seu gênero ou deixe em branco caso prefira não exibi-lo"

--- a/src/components/comum/nome/__snapshots__/Nome.test.js.snap
+++ b/src/components/comum/nome/__snapshots__/Nome.test.js.snap
@@ -28,12 +28,6 @@ exports[`Nome deve seguir a estrutura definida  1`] = `
     <div
       className="input-field col s12 m6 l6"
     >
-      <input
-        id="3"
-        maxLength={40}
-        placeholder="Nome (máximo de 40 caracteres)"
-        type="text"
-      />
       <label
         className="active"
         data-success="right"
@@ -41,6 +35,12 @@ exports[`Nome deve seguir a estrutura definida  1`] = `
       >
         Nome (máximo de 40 caracteres)
       </label>
+      <input
+        id="3"
+        maxLength={40}
+        placeholder="Nome (máximo de 40 caracteres)"
+        type="text"
+      />
     </div>
   </campoTexto>
 </nome>

--- a/src/containers/denuncias/NovaDenunciaContainer.js
+++ b/src/containers/denuncias/NovaDenunciaContainer.js
@@ -85,9 +85,6 @@ NovaDenunciaContainer.propTypes = {
 };
 
 NovaDenunciaContainer.defaultProps = {
-  // criarDenunciaRequisicao: () => {},
-  // denunciaCadastradaComSucesso: false,
-  // limpaEstadoUltimaDencunciaCadastrada: () => {},
   formDenuncia: {},
 };
 


### PR DESCRIPTION
<!--

* Este é um modelo de Pull Request(PR) e serve para guiar a pessoa colaboradora que deseja submeter mudanças no projeto ***Verdade Seja Dita***.
* Caso você não veja necessidade ou sentido em descrever algum tópico, coloque algo como: "Não aplicável".
* Ao abrir uma Issue, é esperado que você tenha concordado com os termos descritos no nosso [código de conduta](CODE_OF_CONDUCT.md).

 -->

### Requisitos

<!--

* Um Pull Request(PR) que não inclua informações suficientes para ser revisado em tempo hábil(cerca 24h), pode dificultar o andamento das pessoas que mantém ou colaboram no projeto.
* Todo o código novo requer testes para evitar regressões: executando `yarn test-coverage` para ver a cobertura de testes do seu código
* Todos os testes unitários devem estar funcionando: rode `yarn test` para executar os testes unitários
* Passar todas as regras de linter/eslint: rode `yarn lint` para executar a análise de código
* Seguir as boas práticas de desenvolvimento de código

-->

### Descrição da Mudança

<!--

* Devemos ser capazes de entender a abordagem da sua mudança a partir desta descrição. Se não tivermos uma boa idéia do que o código fará a partir da descrição aqui, o Pull Request(PR) pode ser revisado com dificuldade. 
* Tenha em mente que a pessoa mantenedora/colaboradora a cargo de revisar este PR pode não estar familiarizado(a) ou não ter trabalhado com o código recentemente, então, seja claro(a).

-->

Esta PR introduz as seguintes modificações:

**Execução de módulos executáveis via `npx`**

Algumas tarefas do projeto dentro do `package.json` eram executadas acessando `node_modules` através do seu caminho relativo (`../node_modules`). O uso do caminho relativo não garante uma execução que funcione entre diferentes ambientes (as tarefas falharam no meu ambiente local, por exemplo). 

As versões mais recentes do npm (incluindo a que se utiliza no projeto) oferecem algumas alternativas para resolver este problema:
- [npm bin](https://docs.npmjs.com/cli/bin): retorna o caminho absoluto de onde dos módulos executáveis do projeto estão instalados
- [npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b): executa um módulo executável

Optei pelo `npx` por deixar as tarefas mais legíveis dentro do `package.json`. Usando o `npm bin` teríamos algo como:

```json
{
  "scripts": {
    "test": "$(npm bin)/jest"
  }
}
```

Outro ponto que pode ser um problema é o fato de o projeto usar o `yarn` em vez de `npm` diretamente. Aparentemente, o [Yarn ainda não oferece uma solução parecida com npx](https://github.com/yarnpkg/yarn/issues/3937). Acredito que se o CI passar com o uso do npx, não devem haver maiores problemas quanto ao uso do npx.

**Inversão da ordem entre labels e campos em alguns componentes**

Por alguma razão, em algumas situações, os navegadores estavam renderizando o label abaixo do campo (em vez de renderizá-lo em cima, como nos demais), o que pode ser visto nas capturas de tela abaixo:

**Chrome:**
![enegrecer-label-chrome](https://user-images.githubusercontent.com/4705127/44041509-5829595c-9ef4-11e8-95ec-5e051b937bf9.png)

**Firefox:**
![enegrecer-label-firefox](https://user-images.githubusercontent.com/4705127/44041519-5fc4d290-9ef4-11e8-8db1-e3c0a7486c65.png)

Ao inverter a ordem do label dentro do componente, o problema foi resolvido.

**O campo gênero passa a ser um campo de texto livre**

O campo gênero deixou de ser um campo de seleção de opções fixas (ComboBox) para tornar-se um campo de texto livre, permitindo que a pessoa se identifique da maneira em que sentir-se mais confortável (ou deixe o campo em branco, caso não queira identificar seu gênero).

### Benefícios

<!-- Quais benefícios serão realizados pela mudança de código? -->
Uma pessoa usuária terá maior liberdade de escolher como descrever seu gênero, tendo até mesmo a opção de não descrevê-lo caso não se sinta confortável.

### Possíveis Desvantagens

Não consegui verificar se a mudança teria algum impacto no backend da aplicação. Acredito que o CI possa ajudar a prover algum feedback em relação à isso.

<!-- Quais são os possíveis efeitos colaterais ou impactos negativos da mudança de código? -->

### Issues relacionados

Não se aplica.
<!-- Informe quaisquer Issues relacionados aqui -->

### Abordagens Alternativas

Se houver sentido, poderia existir um componente que seja uma caixa de seleção de opções fixas (como o componente original) mas que permita, caso a pessoa deseje, introduzir texto livre para descrever o gênero.

<!-- Explique quais outras alternativas foram considerados e por que a versão proposta foi selecionada -->
