### PR TITLE
Correção na exibição da lista de denúncias quando o registro não possui um agressor

### DIFF
--- a/src/sagas/denuncia/listar.js
+++ b/src/sagas/denuncia/listar.js
@@ -1,6 +1,19 @@
 import { takeEvery, put, call } from 'redux-saga/effects';
+import { assign } from 'lodash';
 import { ref } from '../../utils/firebaseUtils';
 import { LISTA_DENUNCIAS_ERRO, LISTA_DENUNCIAS, listaDenunciasSucesso } from '../../actions/listarDenunciasActions';
+
+function extrairDadosDenuncia(pessoaEnvolvida) {
+  const valoresPadrao = { agressor: {}, denunciante: {}, vitima: {} };
+
+  return assign(valoresPadrao, pessoaEnvolvida.val() || {});
+}
+
+function mapearDadosDenuncia(denuncias, pessoaEnvolvida) {
+  const dadosDenuncia = extrairDadosDenuncia(pessoaEnvolvida);
+
+  return assign(denuncias[pessoaEnvolvida.key], dadosDenuncia);
+}
 
 async function recuperaDenunciasDoFirebase() {
   const denunciasResponse = await ref.child('denuncias').orderByKey().once('value');
@@ -15,9 +28,7 @@ async function recuperaDenunciasDoFirebase() {
   const pessoasEnvolvidas = await Promise.all(promisesPessoasEnvolvidas);
 
   pessoasEnvolvidas.forEach((pessoaEnvolvida) => {
-    denuncias[pessoaEnvolvida.key].agressor = pessoaEnvolvida.val().agressor;
-    denuncias[pessoaEnvolvida.key].denunciante = pessoaEnvolvida.val().denunciante;
-    denuncias[pessoaEnvolvida.key].vitima = pessoaEnvolvida.val().vitima;
+    mapearDadosDenuncia(denuncias, pessoaEnvolvida);
   });
 
   return denuncias;


### PR DESCRIPTION
### Requisitos

Não aplicável

### Descrição da Mudança

Foi verificado que a listagem com os dados da denúncia não estava sendo exibida. Esse problema acontece pelo fato do registro no Firebase não ter o node "**agressor**" e com isso o mapeamento dos dados quebrar.

### Benefícios

Corrige o problema de exibição dos dados nulos do nós: "**agressor**", "**denunciante**" e "**vitima**".

### Possíveis Desvantagens

Não aplicável

### Issues relacionados

Closes #287 

### Abordagens Alternativas

Tentei somente fazer a verificação se o valor da _pessoaEnvolvida_ existia, mas caso não fosse informado pelo menos o valor padrão para os três nós "**agressor**", "**denunciante**" e "**vitima**" a renderização da lista também não funciona, uma vez que é esperado que esses nós tenham um objeto.
