### PR TITLE
SEM-ISSUE - Corrige porcentagem de mulheres que estava aparecendo "NaN%

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -21,7 +21,11 @@ export function temMenosDe29Anos(dataNascimento) {
 }
 
 export function obtemPorcentagemDeMulheres(total, totalMulheres) {
-  let percentagem = (totalMulheres * 100) / total;
-  percentagem = parseFloat(percentagem.toFixed(2));
-  return percentagem;
+  if (total > 0) {
+    let percentagem = (totalMulheres * 100) / total;
+    percentagem = parseFloat(percentagem.toFixed(2));
+    return percentagem;
+  }
+
+  return total;
 }

--- a/src/utils/helpers.test.js
+++ b/src/utils/helpers.test.js
@@ -47,4 +47,11 @@ describe('Helpers functions', () => {
     const porcentagem = helpers.obtemPorcentagemDeMulheres(total, mulheres);
     expect(porcentagem).toBe(50);
   });
+
+  it('deve retornar zero se o total de mulheres for zero', () => {
+    const total = 0;
+    const mulheres = 0;
+    const porcentagem = helpers.obtemPorcentagemDeMulheres(total, mulheres);
+    expect(porcentagem).toBe(0);
+  });
 });


### PR DESCRIPTION

<!--

* Este é um modelo de Pull Request(PR) e serve para guiar a pessoa colaboradora que deseja submeter mudanças no projeto ***Verdade Seja Dita***.
* Caso você não veja necessidade ou sentido em descrever algum tópico, coloque algo como: "Não aplicável".
* Ao abrir uma Issue, é esperado que você tenha concordado com os termos descritos no nosso [código de conduta](CODE_OF_CONDUCT.md).

 -->

### Requisitos

<!--

* Um Pull Request(PR) que não inclua informações suficientes para ser revisado em tempo hábil(cerca 24h), pode dificultar o andamento das pessoas que mantém ou colaboram no projeto.
* Todo o código novo requer testes para evitar regressões: executando `yarn test-coverage` para ver a cobertura de testes do seu código
* Todos os testes unitários devem estar funcionando: rode `yarn test` para executar os testes unitários
* Passar todas as regras de linter/eslint: rode `yarn lint` para executar a análise de código
* Seguir as boas práticas de desenvolvimento de código

-->

### Descrição da Mudança

Ao entrar no site `https://enegrecer-e37b3.firebaseapp.com/`, notei que a porcentagem de mulheres estava mostrando `NaN`.
![image](https://user-images.githubusercontent.com/2158040/67524464-20a1c000-f687-11e9-8b42-0ae880fd2dee.png)

<!--

* Devemos ser capazes de entender a abordagem da sua mudança a partir desta descrição. Se não tivermos uma boa idéia do que o código fará a partir da descrição aqui, o Pull Request(PR) pode ser revisado com dificuldade. 
* Tenha em mente que a pessoa mantenedora/colaboradora a cargo de revisar este PR pode não estar familiarizado(a) ou não ter trabalhado com o código recentemente, então, seja claro(a).

-->

### Benefícios

Numero de porcentagem não aparecer quebrado.

### Possíveis Desvantagens

<!-- Quais são os possíveis efeitos colaterais ou impactos negativos da mudança de código? -->

### Issues relacionados

Não encontrei issue relacionada ao problema da porcentagem de mulheres retornando `NaN`

### Abordagens Alternativas

<!-- Explique quais outras alternativas foram considerados e por que a versão proposta foi selecionada -->
